### PR TITLE
[기타] ViewController Transition Animation 기능 추가

### DIFF
--- a/Dayeng/Dayeng/App/SceneDelegate.swift
+++ b/Dayeng/Dayeng/App/SceneDelegate.swift
@@ -97,6 +97,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
     }
 
-
+    func changeRootVC(_ vc: UIViewController, animated: Bool) {
+        guard let window = self.window else { return }
+        window.rootViewController = vc
+        
+        UIView.transition(with: window, duration: 1.0, options: [.transitionCurlUp], animations: nil, completion: nil)
+    }
+    
+    func transitionViewController(_ vc: UIViewController, option: UIView.AnimationOptions) {
+        guard let window = self.window else { return }
+        guard let navi = window.rootViewController as? UINavigationController else { return }
+        UIView.transition(with: window, duration: 1.0, options: option) {
+            navi.viewControllers.append(vc)
+        }
+    }
 }
 

--- a/Dayeng/Dayeng/App/SceneDelegate.swift
+++ b/Dayeng/Dayeng/App/SceneDelegate.swift
@@ -97,7 +97,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
     }
 
-    func changeRootVC(_ vc: UIViewController, animated: Bool) {
+    func changeRootViewController(_ vc: UIViewController, animated: Bool) {
         guard let window = self.window else { return }
         window.rootViewController = vc
         

--- a/Dayeng/Dayeng/App/SceneDelegate.swift
+++ b/Dayeng/Dayeng/App/SceneDelegate.swift
@@ -97,18 +97,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
     }
 
-    func changeRootViewController(_ vc: UIViewController, animated: Bool) {
+    func changeRootViewController(_ viewController: UIViewController) {
         guard let window = self.window else { return }
-        window.rootViewController = vc
+        window.rootViewController = viewController
         
         UIView.transition(with: window, duration: 1.0, options: [.transitionCurlUp], animations: nil, completion: nil)
     }
     
-    func transitionViewController(_ vc: UIViewController, option: UIView.AnimationOptions) {
+    func transitionViewController(_ viewController: UIViewController, option: UIView.AnimationOptions) {
         guard let window = self.window else { return }
-        guard let navi = window.rootViewController as? UINavigationController else { return }
+        guard let navigationController = window.rootViewController as? UINavigationController else { return }
         UIView.transition(with: window, duration: 1.0, options: option) {
-            navi.viewControllers.append(vc)
+            navigationController.viewControllers.append(viewController)
         }
     }
 }

--- a/Dayeng/Dayeng/Presentation/Coordinator/MainCoordinator.swift
+++ b/Dayeng/Dayeng/Presentation/Coordinator/MainCoordinator.swift
@@ -49,7 +49,10 @@ final class MainCoordinator: MainCoordinatorProtocol {
             })
             .disposed(by: disposeBag)
         
-        navigationController.viewControllers = [viewController]
+        let navigationController = UINavigationController(rootViewController: viewController)
+        (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?
+            .changeRootVC(navigationController, animated: false)
+        self.navigationController = navigationController
     }
     
     func showCalendarViewController(ownerType: OwnerType) {

--- a/Dayeng/Dayeng/Presentation/Coordinator/MainCoordinator.swift
+++ b/Dayeng/Dayeng/Presentation/Coordinator/MainCoordinator.swift
@@ -51,7 +51,7 @@ final class MainCoordinator: MainCoordinatorProtocol {
         
         let navigationController = UINavigationController(rootViewController: viewController)
         (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?
-            .changeRootViewController(navigationController, animated: false)
+            .changeRootViewController(navigationController)
         self.navigationController = navigationController
     }
     

--- a/Dayeng/Dayeng/Presentation/Coordinator/MainCoordinator.swift
+++ b/Dayeng/Dayeng/Presentation/Coordinator/MainCoordinator.swift
@@ -51,7 +51,7 @@ final class MainCoordinator: MainCoordinatorProtocol {
         
         let navigationController = UINavigationController(rootViewController: viewController)
         (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?
-            .changeRootVC(navigationController, animated: false)
+            .changeRootViewController(navigationController, animated: false)
         self.navigationController = navigationController
     }
     


### PR DESCRIPTION
# 작업내용
![Simulator Screen Recording - iPhone 14 Pro - 2023-02-12 at 14 22 08](https://user-images.githubusercontent.com/76683388/218294477-a8451746-890a-4a30-8f59-1e20a002c5ef.gif)

- 밑의 코드로 했을 땐, 뷰 전환 이후 화면을 클릭했을 때, dismiss 되는 현상이 발견되었다. 그래서 UIView.transition 함수를 통해 직접 애니메이션을 주는 형식으로 변경함.
```Swift
        let viewController = UIViewController()
        viewController.modalTransitionStyle = .partialCurl
        viewController.modalPresentationStyle = .fullScreen
        present(viewController, animated: true)
```
- 추후에 뷰 전환 애니메이션을 바꾸고 싶으면 밑의 코드를 참고해서 변경하면 됩니다.
```Swift
(UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?
            .transitionViewController(UIViewController(), option: UIView.AnimationOptions)
```