### PR TITLE
[설정] 로그아웃, 회원 탈퇴 (Firebase Auth + Kakao)

### DIFF
--- a/Dayeng/Dayeng.xcodeproj/project.pbxproj
+++ b/Dayeng/Dayeng.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		476A62692993FE460074231E /* QuestionDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476A62682993FE460074231E /* QuestionDTO.swift */; };
 		476A626D2996646A0074231E /* DayengCacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476A626C2996646A0074231E /* DayengCacheService.swift */; };
 		477800F5299B64FC008FFE79 /* DayengDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 477800F4299B64FC008FFE79 /* DayengDefaults.swift */; };
+		4794DB1829B3494B0032AF86 /* SettingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4794DB1729B3494B0032AF86 /* SettingUseCase.swift */; };
+		4794DB1A29B349580032AF86 /* DefaultSettingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4794DB1929B349580032AF86 /* DefaultSettingUseCase.swift */; };
 		4799A65829A7E2380071F8F9 /* DefaultAppleLoginService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4799A65729A7E2380071F8F9 /* DefaultAppleLoginService.swift */; };
 		47B5083F29A9E4490046A982 /* RxKakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 47B5083E29A9E4490046A982 /* RxKakaoSDKAuth */; };
 		47B5084129A9E4490046A982 /* RxKakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 47B5084029A9E4490046A982 /* RxKakaoSDKCommon */; };
@@ -124,6 +126,8 @@
 		476A62682993FE460074231E /* QuestionDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuestionDTO.swift; sourceTree = "<group>"; };
 		476A626C2996646A0074231E /* DayengCacheService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayengCacheService.swift; sourceTree = "<group>"; };
 		477800F4299B64FC008FFE79 /* DayengDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayengDefaults.swift; sourceTree = "<group>"; };
+		4794DB1729B3494B0032AF86 /* SettingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingUseCase.swift; sourceTree = "<group>"; };
+		4794DB1929B349580032AF86 /* DefaultSettingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSettingUseCase.swift; sourceTree = "<group>"; };
 		4799A65729A7E2380071F8F9 /* DefaultAppleLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAppleLoginService.swift; sourceTree = "<group>"; };
 		47B04031299DE62A0018429C /* Dayeng.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Dayeng.entitlements; sourceTree = "<group>"; };
 		47B5084429AA02AF0046A982 /* KakaoLoginService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginService.swift; sourceTree = "<group>"; };
@@ -471,6 +475,7 @@
 			isa = PBXGroup;
 			children = (
 				7603FA21299793B500D2C9C8 /* AlarmSettingUseCase.swift */,
+				4794DB1729B3494B0032AF86 /* SettingUseCase.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -487,8 +492,9 @@
 		76280D22298792680061206A /* Setting */ = {
 			isa = PBXGroup;
 			children = (
-				7603FA1F2996556200D2C9C8 /* DefaultAlarmSettingUseCase.swift */,
 				76280D1F2987922C0061206A /* Protocol */,
+				7603FA1F2996556200D2C9C8 /* DefaultAlarmSettingUseCase.swift */,
+				4794DB1929B349580032AF86 /* DefaultSettingUseCase.swift */,
 			);
 			path = Setting;
 			sourceTree = "<group>";
@@ -767,6 +773,7 @@
 				7628E68C298E4E80002D86F2 /* DefaultFirestoreDatabaseService.swift in Sources */,
 				7628E684298E4DA7002D86F2 /* DefaultUserRepository.swift in Sources */,
 				7603FA202996556200D2C9C8 /* DefaultAlarmSettingUseCase.swift in Sources */,
+				4794DB1829B3494B0032AF86 /* SettingUseCase.swift in Sources */,
 				47B5084529AA02AF0046A982 /* KakaoLoginService.swift in Sources */,
 				7628E680298E4D9C002D86F2 /* UserDTO.swift in Sources */,
 				E56916302998D429006D7231 /* PageType.swift in Sources */,
@@ -815,6 +822,7 @@
 				76003E0F29990EE200F15CAE /* DefaultUserNotificationService.swift in Sources */,
 				4754942829900414008B581D /* DefaultDayengCacheService.swift in Sources */,
 				E5D434002988CDE5004EDFC7 /* SplashViewController.swift in Sources */,
+				4794DB1A29B349580032AF86 /* DefaultSettingUseCase.swift in Sources */,
 				7628E67E298DA61D002D86F2 /* AcceptFriendViewController.swift in Sources */,
 				76F6C0A5298D969700A124CD /* MainViewModel.swift in Sources */,
 				76F6C0AD298D985F00A124CD /* Date+.swift in Sources */,

--- a/Dayeng/Dayeng/App/Coordinator/AppCoordinator.swift
+++ b/Dayeng/Dayeng/App/Coordinator/AppCoordinator.swift
@@ -118,6 +118,7 @@ final class AppCoordinator: AppCoordinatorProtocol {
     
     func showMainViewController() {
         let coordinator = MainCoordinator(navigationController: navigationController)
+        coordinator.delegate = self
         childCoordinators.append(coordinator)
         coordinator.start()
     }
@@ -126,5 +127,6 @@ final class AppCoordinator: AppCoordinatorProtocol {
 extension AppCoordinator: CoordinatorDelegate {
     func didFinished(childCoordinator: Coordinator) {
         childCoordinators = childCoordinators.filter({ $0 !== childCoordinator })
+        showLoginViewController()
     }
 }

--- a/Dayeng/Dayeng/Domain/UseCase/Auth/DefaultLoginUseCase.swift
+++ b/Dayeng/Dayeng/Domain/UseCase/Auth/DefaultLoginUseCase.swift
@@ -171,7 +171,6 @@ final class DefaultLoginUseCase: LoginUseCase {
         userRepository.uploadUser(user: user)
             .do(onNext: {
                 UserDefaults.userID = user.uid
-                DayengDefaults.shared.questions = []
                 DayengDefaults.shared.user = user
             }, onError: { [weak self] _ in
                 guard let self else { return }

--- a/Dayeng/Dayeng/Domain/UseCase/DefaultSplashUseCase.swift
+++ b/Dayeng/Dayeng/Domain/UseCase/DefaultSplashUseCase.swift
@@ -40,7 +40,7 @@ final class DefaultSplashUseCase: SplashUseCase {
                 return Disposables.create()
             }
             
-            if self.kakaoLoginService.isAvailableAutoSignIn() {
+            if self.kakaoLoginService.isLoggedIn() {
                 self.kakaoLoginService.autoSignIn()
                     .do(onNext: { result in
                         if !result { try? Auth.auth().signOut() }
@@ -48,7 +48,7 @@ final class DefaultSplashUseCase: SplashUseCase {
                     .bind(to: observer)
                     .disposed(by: self.disposeBag)
             } else {
-                self.appleLoginService.autoSignIn()
+                self.appleLoginService.isLoggedIn()
                     .do(onNext: { result in
                         if !result { try? Auth.auth().signOut() }
                     })

--- a/Dayeng/Dayeng/Domain/UseCase/Setting/DefaultSettingUseCase.swift
+++ b/Dayeng/Dayeng/Domain/UseCase/Setting/DefaultSettingUseCase.swift
@@ -1,0 +1,57 @@
+//
+//  DefaultSettingUseCase.swift
+//  Dayeng
+//
+//  Created by  sangyeon on 2023/03/04.
+//
+
+import Foundation
+import RxSwift
+import FirebaseAuth
+
+final class DefaultSettingUseCase: SettingUseCase {
+    
+    // MARK: - Properties
+    private let disposeBag = DisposeBag()
+    
+    // MARK: - Dependencies
+    private let appleLoginService: AppleLoginService
+    private let kakaoLoginService: KakaoLoginService
+    
+    // MARK: - LifeCycles
+    init(
+        appleLoginService: AppleLoginService,
+        kakaoLoginService: KakaoLoginService
+    ) {
+        self.appleLoginService = appleLoginService
+        self.kakaoLoginService = kakaoLoginService
+    }
+    
+    func logout() -> Observable<Bool> {
+        Observable.create { [weak self] observer in
+            guard let self else { return Disposables.create() }
+            if Auth.auth().currentUser != nil {
+                do {
+                    try Auth.auth().signOut()
+                } catch {
+                    observer.onNext(false)
+                    observer.onCompleted()
+                }
+            }
+            
+            if self.kakaoLoginService.isAvailableAutoSignIn() {
+                self.kakaoLoginService.signOut()
+                    .subscribe(onCompleted: {
+                        observer.onNext(true)
+                    }, onError: { _ in
+                        observer.onNext(false)
+                    })
+                    .disposed(by: self.disposeBag)
+            } else {    // case: apple login
+//                appleLoginService.signOut()
+            }
+            return Disposables.create()
+        }
+    }
+    
+}

--- a/Dayeng/Dayeng/Domain/UseCase/Setting/DefaultSettingUseCase.swift
+++ b/Dayeng/Dayeng/Domain/UseCase/Setting/DefaultSettingUseCase.swift
@@ -39,7 +39,7 @@ final class DefaultSettingUseCase: SettingUseCase {
                 }
             }
             
-            if self.kakaoLoginService.isAvailableAutoSignIn() {
+            if self.kakaoLoginService.isLoggedIn() {
                 self.kakaoLoginService.signOut()
                     .subscribe(onCompleted: {
                         observer.onNext(true)
@@ -47,8 +47,16 @@ final class DefaultSettingUseCase: SettingUseCase {
                         observer.onNext(false)
                     })
                     .disposed(by: self.disposeBag)
-            } else {    // case: apple login
-//                appleLoginService.signOut()
+            } else {
+                self.appleLoginService.isLoggedIn()
+                    .subscribe(onNext: { result in
+                        if result {
+//                            appleLoginService.signOut()
+                        } else {
+                            observer.onNext(true)
+                        }
+                    })
+                    .disposed(by: self.disposeBag)
             }
             return Disposables.create()
         }
@@ -66,7 +74,7 @@ final class DefaultSettingUseCase: SettingUseCase {
                 }
             }
             
-            if self.kakaoLoginService.isAvailableAutoSignIn() {
+            if self.kakaoLoginService.isLoggedIn() {
                 self.kakaoLoginService.unlink()
                     .subscribe(onCompleted: {
                         observer.onNext(true)
@@ -74,8 +82,16 @@ final class DefaultSettingUseCase: SettingUseCase {
                         observer.onNext(false)
                     })
                     .disposed(by: self.disposeBag)
-            } else {    // case: apple login
-//                appleLoginService.withdrawal()
+            } else {
+                self.appleLoginService.isLoggedIn()
+                    .subscribe(onNext: { result in
+                        if result {
+//                            appleLoginService.withdrawal()
+                        } else {
+                            observer.onNext(true)
+                        }
+                    })
+                    .disposed(by: self.disposeBag)
             }
             return Disposables.create()
         }

--- a/Dayeng/Dayeng/Domain/UseCase/Setting/DefaultSettingUseCase.swift
+++ b/Dayeng/Dayeng/Domain/UseCase/Setting/DefaultSettingUseCase.swift
@@ -54,4 +54,31 @@ final class DefaultSettingUseCase: SettingUseCase {
         }
     }
     
+    func withdrawal() -> Observable<Bool> {
+        Observable.create { [weak self] observer in
+            guard let self else { return Disposables.create() }
+            if let user = Auth.auth().currentUser {
+                user.delete { error in
+                    if error != nil {
+                        observer.onNext(false)
+                        observer.onCompleted()
+                    }
+                }
+            }
+            
+            if self.kakaoLoginService.isAvailableAutoSignIn() {
+                self.kakaoLoginService.unlink()
+                    .subscribe(onCompleted: {
+                        observer.onNext(true)
+                    }, onError: { _ in
+                        observer.onNext(false)
+                    })
+                    .disposed(by: self.disposeBag)
+            } else {    // case: apple login
+//                appleLoginService.withdrawal()
+            }
+            return Disposables.create()
+        }
+    }
+    
 }

--- a/Dayeng/Dayeng/Domain/UseCase/Setting/Protocol/SettingUseCase.swift
+++ b/Dayeng/Dayeng/Domain/UseCase/Setting/Protocol/SettingUseCase.swift
@@ -10,4 +10,5 @@ import RxSwift
 
 protocol SettingUseCase {
     func logout() -> Observable<Bool>
+    func withdrawal() -> Observable<Bool>
 }

--- a/Dayeng/Dayeng/Domain/UseCase/Setting/Protocol/SettingUseCase.swift
+++ b/Dayeng/Dayeng/Domain/UseCase/Setting/Protocol/SettingUseCase.swift
@@ -1,0 +1,13 @@
+//
+//  SettingUseCase.swift
+//  Dayeng
+//
+//  Created by  sangyeon on 2023/03/04.
+//
+
+import Foundation
+import RxSwift
+
+protocol SettingUseCase {
+    func logout() -> Observable<Bool>
+}

--- a/Dayeng/Dayeng/Presentation/Coordinator/MainCoordinator.swift
+++ b/Dayeng/Dayeng/Presentation/Coordinator/MainCoordinator.swift
@@ -68,7 +68,15 @@ final class MainCoordinator: MainCoordinatorProtocol {
     
     func showSettingViewController() {
         let coordinator = SettingCoordinator(navigationController: navigationController)
+        coordinator.delegate = self
         childCoordinators.append(coordinator)
         coordinator.start()
+    }
+}
+
+extension MainCoordinator: CoordinatorDelegate {
+    func didFinished(childCoordinator: Coordinator) {
+        childCoordinators = childCoordinators.filter({ $0 !== childCoordinator })
+        delegate?.didFinished(childCoordinator: self)
     }
 }

--- a/Dayeng/Dayeng/Presentation/Coordinator/SettingCoordinator.swift
+++ b/Dayeng/Dayeng/Presentation/Coordinator/SettingCoordinator.swift
@@ -56,12 +56,14 @@ final class SettingCoordinator: NSObject, SettingCoordinatorProtocol {
         viewModel.logoutSuccess
             .subscribe(onNext: { [weak self] in
                 guard let self else { return }
+                self.navigationController.viewControllers.last?.hideIndicator()
                 self.delegate?.didFinished(childCoordinator: self)
             })
             .disposed(by: disposeBag)
         viewModel.withdrawalSuccess
             .subscribe(onNext: { [weak self] in
                 guard let self else { return }
+                self.navigationController.viewControllers.last?.hideIndicator()
                 self.delegate?.didFinished(childCoordinator: self)
             })
             .disposed(by: disposeBag)

--- a/Dayeng/Dayeng/Presentation/Coordinator/SettingCoordinator.swift
+++ b/Dayeng/Dayeng/Presentation/Coordinator/SettingCoordinator.swift
@@ -29,7 +29,11 @@ final class SettingCoordinator: NSObject, SettingCoordinatorProtocol {
     }
     
     func showSettingViewController() {
-        let viewModel = SettingViewModel()
+        let useCase = DefaultSettingUseCase(
+            appleLoginService: DefaultAppleLoginService(),
+            kakaoLoginService: DefaultKakaoLoginService()
+        )
+        let viewModel = SettingViewModel(useCase: useCase)
         let viewController = SettingViewController(viewModel: viewModel)
         viewModel.alarmCellDidTapped
             .subscribe(onNext: { [weak self] in
@@ -47,6 +51,12 @@ final class SettingCoordinator: NSObject, SettingCoordinatorProtocol {
             .subscribe(onNext: { [weak self] in
                 guard let self else { return }
                 self.showWebViewController(url: PageType.about.url)
+            })
+            .disposed(by: disposeBag)
+        viewModel.logoutSuccess
+            .subscribe(onNext: { [weak self] in
+                guard let self else { return }
+                self.delegate?.didFinished(childCoordinator: self)
             })
             .disposed(by: disposeBag)
         navigationController.pushViewController(viewController, animated: true)

--- a/Dayeng/Dayeng/Presentation/Coordinator/SettingCoordinator.swift
+++ b/Dayeng/Dayeng/Presentation/Coordinator/SettingCoordinator.swift
@@ -59,6 +59,12 @@ final class SettingCoordinator: NSObject, SettingCoordinatorProtocol {
                 self.delegate?.didFinished(childCoordinator: self)
             })
             .disposed(by: disposeBag)
+        viewModel.withdrawalSuccess
+            .subscribe(onNext: { [weak self] in
+                guard let self else { return }
+                self.delegate?.didFinished(childCoordinator: self)
+            })
+            .disposed(by: disposeBag)
         navigationController.pushViewController(viewController, animated: true)
     }
     

--- a/Dayeng/Dayeng/Presentation/Setting/ViewController/SettingViewController.swift
+++ b/Dayeng/Dayeng/Presentation/Setting/ViewController/SettingViewController.swift
@@ -59,13 +59,6 @@ final class SettingViewController: UIViewController {
     }
     
     // MARK: - UI properties
-    private lazy var backgroundImage: UIImageView = {
-        var imageView: UIImageView = UIImageView()
-        imageView.image = UIImage(named: "paperBackground")
-        
-        return imageView
-    }()
-    
     private var collectionView: UICollectionView!
     
     // MARK: - Properties
@@ -128,16 +121,10 @@ final class SettingViewController: UIViewController {
     }
     
     private func setupViews() {
-        view.addSubview(backgroundImage)
+        view.addBackgroundImage()
     }
     
     private func configureUI() {
-        backgroundImage.snp.makeConstraints {
-            $0.center.equalToSuperview()
-            $0.leading.trailing.equalToSuperview().inset(-50)
-            $0.top.bottom.equalToSuperview().inset(-100)
-        }
-        
         configureCollectionView()
     }
     

--- a/Dayeng/Dayeng/Presentation/Setting/ViewController/SettingViewController.swift
+++ b/Dayeng/Dayeng/Presentation/Setting/ViewController/SettingViewController.swift
@@ -115,6 +115,7 @@ final class SettingViewController: UIViewController {
                     type: .twoButton,
                     rightActionHandler: { [weak self] in
                         guard let self else { return }
+                        self.showIndicator()
                         self.logoutDidTapped.onNext(())
                 })
             })
@@ -130,6 +131,7 @@ final class SettingViewController: UIViewController {
                     type: .twoButton,
                     rightActionHandler: { [weak self] in
                         guard let self else { return }
+                        self.showIndicator()
                         self.withdrawalDidTapped.onNext(())
                 })
             })
@@ -160,7 +162,11 @@ final class SettingViewController: UIViewController {
                 self.showAlert(
                     title: "로그아웃에 실패했습니다",
                     message: "다시 시도해주세요",
-                    type: .oneButton
+                    type: .oneButton,
+                    rightActionHandler: { [weak self] in
+                        guard let self else { return }
+                        self.hideIndicator()
+                    }
                 )
             })
             .disposed(by: disposeBag)
@@ -171,7 +177,11 @@ final class SettingViewController: UIViewController {
                 self.showAlert(
                     title: "회원 탈퇴에 실패했습니다",
                     message: "다시 시도해주세요",
-                    type: .oneButton
+                    type: .oneButton,
+                    rightActionHandler: { [weak self] in
+                        guard let self else { return }
+                        self.hideIndicator()
+                    }
                 )
             })
             .disposed(by: disposeBag)

--- a/Dayeng/Dayeng/Presentation/Setting/ViewModel/SettingViewModel.swift
+++ b/Dayeng/Dayeng/Presentation/Setting/ViewModel/SettingViewModel.swift
@@ -13,18 +13,30 @@ final class SettingViewModel {
     // MARK: - Input
     struct Input {
         var cellDidTapped: Observable<IndexPath>
+        var logoutDidTapped: Observable<Void>
     }
+    
     // MARK: - Output
     struct Output {
         var showMailComposeViewController = PublishRelay<MessageUIType>()
+        var logoutFailed = PublishRelay<Void>()
     }
-    // MARK: - Dependency
-    var disposeBag = DisposeBag()
+    
+    // MARK: - Properties
+    private var disposeBag = DisposeBag()
     var alarmCellDidTapped = PublishRelay<Void>()
     var openSourceCellDidTapped = PublishRelay<Void>()
     var aboutCellDidTapped = PublishRelay<Void>()
+    var logoutSuccess = PublishRelay<Void>()
+    var logoutFailed = PublishRelay<Void>()
+    
+    // MARK: - Dependency
+    private let useCase: SettingUseCase
     
     // MARK: - LifeCycle
+    init(useCase: SettingUseCase) {
+        self.useCase = useCase
+    }
     
     // MARK: - Helper
     func transform(input: Input) -> Output {
@@ -39,9 +51,7 @@ final class SettingViewModel {
                 switch (section, row) {
                 case (0, 0):
                     self.alarmCellDidTapped.accept(())
-                case (1, 0):
-                    break
-                case (1, 1):
+                case (1, 1): // 회원 탈퇴
                     break
                 case (2, 0): // 추천
                     output.showMailComposeViewController.accept(.recommendQuestion)
@@ -54,6 +64,22 @@ final class SettingViewModel {
                 default:
                     break
                 }
+            })
+            .disposed(by: disposeBag)
+        
+        input.logoutDidTapped
+            .subscribe(onNext: { [weak self] in
+                guard let self else { return }
+                self.useCase.logout()
+                    .subscribe(onNext: { [weak self] result in
+                        guard let self else { return }
+                        if result {
+                            self.logoutSuccess.accept(())
+                        } else {
+                            self.logoutFailed.accept(())
+                        }
+                    })
+                    .disposed(by: self.disposeBag)
             })
             .disposed(by: disposeBag)
         

--- a/Dayeng/Dayeng/Presentation/Setting/ViewModel/SettingViewModel.swift
+++ b/Dayeng/Dayeng/Presentation/Setting/ViewModel/SettingViewModel.swift
@@ -14,12 +14,14 @@ final class SettingViewModel {
     struct Input {
         var cellDidTapped: Observable<IndexPath>
         var logoutDidTapped: Observable<Void>
+        var withdrawalDidTapped: Observable<Void>
     }
     
     // MARK: - Output
     struct Output {
         var showMailComposeViewController = PublishRelay<MessageUIType>()
         var logoutFailed = PublishRelay<Void>()
+        var withdrawalFailed = PublishRelay<Void>()
     }
     
     // MARK: - Properties
@@ -28,7 +30,8 @@ final class SettingViewModel {
     var openSourceCellDidTapped = PublishRelay<Void>()
     var aboutCellDidTapped = PublishRelay<Void>()
     var logoutSuccess = PublishRelay<Void>()
-    var logoutFailed = PublishRelay<Void>()
+    var withdrawalSuccess = PublishRelay<Void>()
+    
     
     // MARK: - Dependency
     private let useCase: SettingUseCase
@@ -76,7 +79,23 @@ final class SettingViewModel {
                         if result {
                             self.logoutSuccess.accept(())
                         } else {
-                            self.logoutFailed.accept(())
+                            output.logoutFailed.accept(())
+                        }
+                    })
+                    .disposed(by: self.disposeBag)
+            })
+            .disposed(by: disposeBag)
+        
+        input.withdrawalDidTapped
+            .subscribe(onNext: { [weak self] in
+                guard let self else { return }
+                self.useCase.withdrawal()
+                    .subscribe(onNext: { [weak self] result in
+                        guard let self else { return }
+                        if result {
+                            self.withdrawalSuccess.accept(())
+                        } else {
+                            output.withdrawalFailed.accept(())
                         }
                     })
                     .disposed(by: self.disposeBag)

--- a/Dayeng/Dayeng/Util/Service/AppleLoginService.swift
+++ b/Dayeng/Dayeng/Util/Service/AppleLoginService.swift
@@ -11,5 +11,5 @@ import FirebaseAuth
 
 protocol AppleLoginService {
     func signIn() -> Observable<(credential: OAuthCredential, name: String)>
-    func autoSignIn() -> Observable<Bool>
+    func isLoggedIn() -> Observable<Bool>
 }

--- a/Dayeng/Dayeng/Util/Service/DefaultAppleLoginService.swift
+++ b/Dayeng/Dayeng/Util/Service/DefaultAppleLoginService.swift
@@ -69,7 +69,7 @@ final class DefaultAppleLoginService: AppleLoginService {
         }
     }
     
-    func autoSignIn() -> Observable<Bool> {
+    func isLoggedIn() -> Observable<Bool> {
         Observable.create { observer in
             guard let userID = UserDefaults.appleID else {
                 observer.onNext(false)

--- a/Dayeng/Dayeng/Util/Service/DefaultKakaoLoginService.swift
+++ b/Dayeng/Dayeng/Util/Service/DefaultKakaoLoginService.swift
@@ -20,7 +20,7 @@ final class DefaultKakaoLoginService: KakaoLoginService {
     
     private let disposeBag = DisposeBag()
     
-    func isAvailableAutoSignIn() -> Bool {
+    func isLoggedIn() -> Bool {
         AuthApi.hasToken()
     }
     

--- a/Dayeng/Dayeng/Util/Service/KakaoLoginService.swift
+++ b/Dayeng/Dayeng/Util/Service/KakaoLoginService.swift
@@ -9,7 +9,7 @@ import Foundation
 import RxSwift
 
 protocol KakaoLoginService {
-    func isAvailableAutoSignIn() -> Bool
+    func isLoggedIn() -> Bool
     func autoSignIn() -> Observable<Bool>
     func signIn() -> Observable<(email: String, password: String, userName: String)>
     func signOut() -> Completable


### PR DESCRIPTION
## 작업 내용:

<!-- 
  GIF 넣기
  작업이 된 기능을 상세하게 적어주세요!
-->

### 로그아웃 + 회원 탈퇴

- 로그아웃/탈퇴 후 로그인 화면으로 전환합니다.
- 로그아웃/탈퇴에 실패할 경우, alert 창을 띄워줍니다.

로그아웃| 회원 탈퇴
-----|-----
![RPReplay_Final1677995343](https://user-images.githubusercontent.com/68235938/222943975-a96c55b4-7abc-46e0-b3e5-ee785d399ba8.gif) | ![RPReplay_Final1677995361](https://user-images.githubusercontent.com/68235938/222943966-9f852206-7e23-428b-8992-3b7d2a9ac687.gif)

## 질문:

- alert에서 "확인" 클릭시 딜레이 없이 로그아웃/탈퇴되어 로그인 화면으로 가긴 하던데 그래도 인디케이터 넣어야 할까요?

## 참고:

- 애플 로그아웃/탈퇴(revoke)는 api 요청 해야해서 아직입니다!
https://developer.apple.com/documentation/sign_in_with_apple/revoke_tokens

### 확인 사항:
- [x] 양심적인 PR양을 준수하였습니다.