### PR TITLE
[HotFix] Apple Login에서 UserDefaults.userID가 nil 뜨는 현상

### DIFF
--- a/Dayeng/Dayeng.xcodeproj/project.pbxproj
+++ b/Dayeng/Dayeng.xcodeproj/project.pbxproj
@@ -1171,8 +1171,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 9.0.0;
 			};
 		};
 		76280D2B29879F770061206A /* XCRemoteSwiftPackageReference "lottie-ios" */ = {

--- a/Dayeng/Dayeng/Domain/UseCase/Auth/DefaultLoginUseCase.swift
+++ b/Dayeng/Dayeng/Domain/UseCase/Auth/DefaultLoginUseCase.swift
@@ -132,6 +132,7 @@ final class DefaultLoginUseCase: LoginUseCase {
                 } else {    // 이전 로그인 기록 O
                     self.userRepository.fetchUser(userID: uid)
                         .map { user in
+                            UserDefaults.userID = user.uid
                             DayengDefaults.shared.user = user
                             return
                         }


### PR DESCRIPTION
## 작업내용

- 기존 코드에서 Apple Login 으로 로그인했을 때 UserDefaults에 userID를 저장하지않아서 문제 발생해서 수정함.
   -  Main 뷰컨에서 fetchUser할 때 UserDefaults.userID를 통해 nil 인지 아닌지 판단할 때 계속 nil만 뜨는 현상이었음.

![image](https://user-images.githubusercontent.com/76683388/229669898-00ee4783-8366-4bf6-9e03-7483af7d6dea.png)
- 해당 오류의 원인은 version이 맞지않아서인데, 버전을 9.0.0으로 바꿔서 해결.