### PR TITLE
[메인, 달력] 연동

### DIFF
--- a/Dayeng/Dayeng/Domain/UseCase/Calendar/DefaultCalendarUseCase.swift
+++ b/Dayeng/Dayeng/Domain/UseCase/Calendar/DefaultCalendarUseCase.swift
@@ -48,6 +48,9 @@ final class DefaultCalendarUseCase: CalendarUseCase {
         switch ownerType {
         case .mine:
             if let user = DayengDefaults.shared.user {
+                if user.answers.last?.date == Date().convertToString(format: "yyyy.MM.dd.E") {
+                    return user.currentIndex - 1
+                }
                 return user.currentIndex
             } else {
                 return -1

--- a/Dayeng/Dayeng/Domain/UseCase/Main/DefaultMainUseCase.swift
+++ b/Dayeng/Dayeng/Domain/UseCase/Main/DefaultMainUseCase.swift
@@ -13,6 +13,7 @@ final class DefaultMainUseCase: MainUseCase {
     private let userRepository: UserRepository
     private let questionRepository: QuestionRepository
     private let disposeBag = DisposeBag()
+    private let ownerType: OwnerType
     
     enum MainUseCaseError: Error {
         case noUserError
@@ -21,9 +22,12 @@ final class DefaultMainUseCase: MainUseCase {
     
     // MARK: - LifeCycle
     init(userRepository: UserRepository,
-         questionRepository: QuestionRepository) {
+         questionRepository: QuestionRepository,
+         ownerType: OwnerType
+    ) {
         self.userRepository = userRepository
         self.questionRepository = questionRepository
+        self.ownerType = ownerType
     }
     
     // MARK: - Helper
@@ -36,9 +40,32 @@ final class DefaultMainUseCase: MainUseCase {
                     return (question, answer)
                 }, self.getBlurStartingIndex())
             }
+    func fetchOwnerType() -> OwnerType {
+        return ownerType
     }
     
-    func getBlurStartingIndex() -> Int? {
+    func fetchData() -> Observable<([(Question, Answer?)], Int?)> {
+        switch ownerType {
+        case .mine:
+            return Observable.zip(fetchQuestions(), fetchAnswers())
+                .map { [weak self] questions, answers in
+                    guard let self else { throw MainUseCaseError.noSelfError }
+                    return (questions.enumerated().map { (index, question) in
+                        let answer = answers.count > index ? answers[index] : nil
+                        return (question, answer)
+                    }, self.getBlurStartingIndex())
+                }
+        case .friend(let user):
+            return Observable.zip(fetchQuestions(), Observable.of(user.answers))
+                .map { questions, answers in
+                    (answers.enumerated().map {
+                        (questions[$0.offset], $0.element)
+                    }, nil)
+                }
+        }
+    }
+
+    private func getBlurStartingIndex() -> Int? {
         guard let user = DayengDefaults.shared.user,
               user.currentIndex < DayengDefaults.shared.questions.count else {
             return nil

--- a/Dayeng/Dayeng/Domain/UseCase/Main/Protocol/MainUseCase.swift
+++ b/Dayeng/Dayeng/Domain/UseCase/Main/Protocol/MainUseCase.swift
@@ -9,5 +9,6 @@ import Foundation
 import RxSwift
 
 protocol MainUseCase {
+    func fetchOwnerType() -> OwnerType
     func fetchData() -> Observable<([(Question, Answer?)], Int?)>
 }

--- a/Dayeng/Dayeng/Domain/UseCase/Main/Protocol/MainUseCase.swift
+++ b/Dayeng/Dayeng/Domain/UseCase/Main/Protocol/MainUseCase.swift
@@ -9,6 +9,8 @@ import Foundation
 import RxSwift
 
 protocol MainUseCase {
+    var firstShowingIndex: BehaviorSubject<Int?> { get set }
+    
     func fetchOwnerType() -> OwnerType
     func fetchData() -> Observable<([(Question, Answer?)], Int?)>
 }

--- a/Dayeng/Dayeng/Presentation/Calendar/ViewController/CalendarViewController.swift
+++ b/Dayeng/Dayeng/Presentation/Calendar/ViewController/CalendarViewController.swift
@@ -20,7 +20,6 @@ final class CalendarViewController: UIViewController {
     
     // MARK: - Properties
     private let viewModel: CalendarViewModel
-    
     private let disposeBag = DisposeBag()
     
     // MARK: - Lifecycles
@@ -46,7 +45,7 @@ final class CalendarViewController: UIViewController {
         let input = CalendarViewModel.Input(
             viewDidLoad: rx.viewDidLoad.map { _ in }.asObservable(),
             homeButtonDidTapped: homeButton.rx.tap.asObservable(),
-            cellDidTapped: collectionView.rx.itemSelected.map { _ in }
+            cellDidTapped: collectionView.rx.itemSelected.map { $0.row }
         )
         
         let output = viewModel.transform(input: input)

--- a/Dayeng/Dayeng/Presentation/Calendar/ViewModel/CalendarViewModel.swift
+++ b/Dayeng/Dayeng/Presentation/Calendar/ViewModel/CalendarViewModel.swift
@@ -14,7 +14,7 @@ final class CalendarViewModel {
     struct Input {
         var viewDidLoad: Observable<Void>
         var homeButtonDidTapped: Observable<Void>
-        var cellDidTapped: Observable<Void>
+        var cellDidTapped: Observable<Int>
     }
     
     // MARK: - Output
@@ -31,6 +31,7 @@ final class CalendarViewModel {
     private let disposeBag = DisposeBag()
     let homeButtonDidTapped = PublishRelay<Void>()
     let cannotFindUserError = PublishSubject<Void>()
+    let dayDidTapped = PublishRelay<Int>()
     
     // MARK: - LifeCycle
     init(useCase: CalendarUseCase) {
@@ -55,7 +56,18 @@ final class CalendarViewModel {
         input.homeButtonDidTapped
             .bind(to: homeButtonDidTapped)
             .disposed(by: disposeBag)
-        
+                
+        input.cellDidTapped
+                .filter { [weak self] index in
+                    guard let self else { return false }
+                    
+                    if self.useCase.fetchOwnerType() != .mine && index >= self.useCase.fetchCurrentIndex() {
+                        return false
+                    }
+                    return true
+                }
+            .bind(to: dayDidTapped)
+            .disposed(by: disposeBag)
         return output
     }
 }

--- a/Dayeng/Dayeng/Presentation/Common/View/CommonCalendarCell.swift
+++ b/Dayeng/Dayeng/Presentation/Common/View/CommonCalendarCell.swift
@@ -67,25 +67,25 @@ final class CommonCalendarCell: UICollectionViewCell {
     
     func bind(index: Int, answer: Answer?, currentIndex: Int) {
         numberLabel.text = "\(index + 1)"
-        
-        if index == currentIndex {
-            numberLabel.textColor = .dayengMain
+        numberLabel.textColor = (index == currentIndex) ? .dayengMain : .black
+
+        if let answer = answer {
+            statusLabel.text = fetchDate(answer.date)
+            if answer.answer.isEmpty {
+                statusLabel.text = "X"
+            }
+        } else {
+            statusLabel.text = ""
         }
-        
-        guard let answer else {
+
+        if index > currentIndex {
             let imageAttachment = NSTextAttachment()
             imageAttachment.image = UIImage(named: "lock")
             imageAttachment.setImageHeight(height: 20)
-            
+
             let attributedString = NSMutableAttributedString(string: "")
             attributedString.append(NSAttributedString(attachment: imageAttachment))
             statusLabel.attributedText = attributedString
-            return
-        }
-        
-        statusLabel.text = fetchDate(answer.date)
-        if answer.answer.isEmpty {
-            statusLabel.text = "X"
         }
     }
     

--- a/Dayeng/Dayeng/Presentation/Common/View/CommonCalendarCell.swift
+++ b/Dayeng/Dayeng/Presentation/Common/View/CommonCalendarCell.swift
@@ -70,7 +70,6 @@ final class CommonCalendarCell: UICollectionViewCell {
         
         if index == currentIndex {
             numberLabel.textColor = .dayengMain
-            return
         }
         
         guard let answer else {

--- a/Dayeng/Dayeng/Presentation/Coordinator/FriendCoordinator.swift
+++ b/Dayeng/Dayeng/Presentation/Coordinator/FriendCoordinator.swift
@@ -96,10 +96,31 @@ final class FriendCoordinator: FriendCoordinatorProtocol {
             })
             .disposed(by: disposeBag)
         
+        viewModel.dayDidTapped
+            .subscribe(onNext: { [weak self] index in
+                guard let self else { return }
+                self.showFriendMainViewController(index, user)
+            })
+            .disposed(by: disposeBag)
+        
         navigationController.pushViewController(viewController, animated: true)
     }
     
     func returnMainViewController() {
         navigationController.popToRootViewController(animated: true)
+    }
+    
+    func showFriendMainViewController(_ index: Int, _ user: User) {
+        let firestoreService = DefaultFirestoreDatabaseService()
+        let userRepository = DefaultUserRepository(firestoreService: firestoreService)
+        let questionRepository = DefaultQuestionRepository(firestoreService: firestoreService)
+        let useCase = DefaultMainUseCase(userRepository: userRepository,
+                                         questionRepository: questionRepository,
+                                         ownerType: .friend(user: user))
+        useCase.firstShowingIndex.onNext(index)
+        
+        let viewModel = MainViewModel(useCase: useCase)
+        let viewController = MainViewController(viewModel: viewModel)
+        navigationController.pushViewController(viewController, animated: true)
     }
 }

--- a/Dayeng/Dayeng/Presentation/Main/View/MainCell.swift
+++ b/Dayeng/Dayeng/Presentation/Main/View/MainCell.swift
@@ -13,6 +13,7 @@ final class MainCell: UICollectionViewCell {
     lazy var mainView = {
        CommonMainView()
     }()
+    
     lazy var lockedLabel = {
         let label = UILabel()
         label.text = "질문은 하루에 하나씩 공개됩니다"
@@ -28,14 +29,12 @@ final class MainCell: UICollectionViewCell {
         return imageView
     }()
     
-    lazy var blurImageView = {
-        let imageView = UIImageView(image: UIImage.mainBlur?.resized(scaledToWidth: frame.width-30))
+    lazy var blurView = {
+        let imageView = UIImageView()
         imageView.backgroundColor = .white
-        imageView.isHidden = true
-        imageView.contentMode = .top
-        imageView.alpha = 0.6
         imageView.layer.cornerRadius = 20
-        imageView.clipsToBounds = true
+        imageView.alpha = 0.6
+        imageView.isHidden = true
         return imageView
     }()
     
@@ -63,7 +62,7 @@ final class MainCell: UICollectionViewCell {
     // MARK: - Helpers
     private func setupViews() {
         addSubview(mainView)
-        addSubview(blurImageView)
+        addSubview(blurView)
         addSubview(lockedLabel)
         addSubview(lockerView)
         configureUI()
@@ -77,7 +76,7 @@ final class MainCell: UICollectionViewCell {
         mainView.dateLabel.snp.updateConstraints {
             $0.top.equalToSuperview().offset(40)
         }
-        blurImageView.snp.makeConstraints {
+        blurView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(15)
             $0.bottom.equalToSuperview().offset(-150)
             $0.leading.trailing.equalToSuperview().inset(15)
@@ -87,20 +86,40 @@ final class MainCell: UICollectionViewCell {
             $0.top.equalToSuperview().offset(200)
         }
         lockerView.snp.makeConstraints {
-            $0.centerX.equalTo(blurImageView)
+            $0.centerX.equalTo(blurView)
             $0.top.equalTo(lockedLabel).offset(30)
             $0.width.height.equalTo(70)
         }
     }
     
     func blur() {
+        if blurView.image != nil {
+            [blurView, lockerView, lockedLabel].forEach { $0.isHidden = false }
+            mainView.isHidden = true
+            return
+        }
+        
+        let renderer = UIGraphicsImageRenderer(bounds: bounds)
+        let uiImage = renderer.image(actions: { context in
+            layer.render(in: context.cgContext)
+        })
+        
+        guard let ciImage = CIImage(image: uiImage),
+              let blurFilter = CIFilter(name: "CIGaussianBlur") else { return }
+
+        blurFilter.setValue(9, forKey: kCIInputRadiusKey)
+        blurFilter.setValue(ciImage, forKey: kCIInputImageKey)
+
+        guard let blurredImage = blurFilter.outputImage else { return }
+
+        blurView.image = UIImage(ciImage: blurredImage)
+        [blurView, lockerView, lockedLabel].forEach { $0.isHidden = false }
         mainView.isHidden = true
-        [blurImageView, lockerView, lockedLabel].forEach { $0.isHidden = false }
     }
 
     func unBlur() {
         mainView.isHidden = false
-        [blurImageView, lockerView, lockedLabel].forEach { $0.isHidden = true }
+        [blurView, lockerView, lockedLabel].forEach { $0.isHidden = true }
     }
 
 }

--- a/Dayeng/Dayeng/Presentation/Main/ViewController/MainViewController.swift
+++ b/Dayeng/Dayeng/Presentation/Main/ViewController/MainViewController.swift
@@ -86,7 +86,7 @@ final class MainViewController: UIViewController {
         navigationController?.navigationBar.tintColor = .black
         
         navigationItem.title = ""
-        navigationItem.leftBarButtonItem = calendarButton
+        navigationController?.navigationBar.topItem?.title = ""
     }
     
     private func setupViews() {

--- a/Dayeng/Dayeng/Presentation/Main/ViewController/MainViewController.swift
+++ b/Dayeng/Dayeng/Presentation/Main/ViewController/MainViewController.swift
@@ -179,6 +179,13 @@ final class MainViewController: UIViewController {
                     section: 0)
             })
             .disposed(by: disposeBag)
+    
+        if output.ownerType != .mine {
+            bindFriend(output: output)
+            return
+        }
+        
+        navigationItem.leftBarButtonItem = calendarButton
         
         collectionView.rx.willDisplayCell
             .subscribe(onNext: { [weak self] cell, indexPath in
@@ -210,15 +217,19 @@ final class MainViewController: UIViewController {
         
         titleViewDidTapped.withLatestFrom(output.startBluringIndex)
             .subscribe(onNext: { [weak self] startBluringIndex in
+    
+    private func bindFriend(output: MainViewModel.Output) {
+        friendButton.isHidden = true
+        settingButton.isHidden = true
+        collectionView.rx.willDisplayCell
+            .subscribe(onNext: { [weak self] _, _ in
                 guard let self else { return }
-                let indexPath = IndexPath(
-                    row: (startBluringIndex ?? output.questionsAnswers.value.count)-1,
-                    section: 0
-                )
-                
-                self.collectionView.scrollToItem(at: indexPath,
-                                                 at: .centeredVertically,
-                                                 animated: true)
+                if let initialIndexPath = self.initialIndexPath {
+                    self.collectionView.scrollToItem(at: initialIndexPath,
+                                                     at: .centeredVertically,
+                                                     animated: false)
+                    self.initialIndexPath = nil
+                }
             })
             .disposed(by: disposeBag)
     }

--- a/Dayeng/Dayeng/Presentation/Main/ViewController/MainViewController.swift
+++ b/Dayeng/Dayeng/Presentation/Main/ViewController/MainViewController.swift
@@ -168,11 +168,6 @@ final class MainViewController: UIViewController {
             ) { (index, questionAnswer, cell) in
                 let (question, answer) = questionAnswer
                 cell.mainView.bind(question, answer)
-                
-                guard let startIndex = output.startBluringIndex.value else { return }
-                if index >= startIndex {
-                    cell.blur()
-                }
             }
             .disposed(by: disposeBag)
         
@@ -198,7 +193,10 @@ final class MainViewController: UIViewController {
                 self.editButtonDisposables[indexPath.row] = cell.mainView.editButtonDidTapped
                     .map { indexPath.row }
                     .bind(to: self.editButtonDidTapped)
-                
+                guard let blurIndex = output.startBluringIndex.value else { return }
+                if indexPath.row >= blurIndex {
+                    cell.blur()
+                }
             })
             .disposed(by: disposeBag)
         

--- a/Dayeng/Dayeng/Presentation/Main/ViewModel/MainViewModel.swift
+++ b/Dayeng/Dayeng/Presentation/Main/ViewModel/MainViewModel.swift
@@ -20,6 +20,7 @@ final class MainViewModel {
     }
     // MARK: - Output
     struct Output {
+        let ownerType: OwnerType
         var questionsAnswers = BehaviorRelay<[(Question, Answer?)]>(value: [])
         var startBluringIndex = BehaviorRelay<Int?>(value: nil)
     }
@@ -40,7 +41,8 @@ final class MainViewModel {
     
     // MARK: - Helper
     func transform(input: Input) -> Output {
-        let output = Output()
+        let output = Output(ownerType: useCase.fetchOwnerType())
+        
         
         input.viewWillAppear
             .subscribe(onNext: { [weak self] _ in

--- a/Dayeng/Dayeng/Presentation/Main/ViewModel/MainViewModel.swift
+++ b/Dayeng/Dayeng/Presentation/Main/ViewModel/MainViewModel.swift
@@ -23,6 +23,7 @@ final class MainViewModel {
         let ownerType: OwnerType
         var questionsAnswers = BehaviorRelay<[(Question, Answer?)]>(value: [])
         var startBluringIndex = BehaviorRelay<Int?>(value: nil)
+        var firstShowingIndex = BehaviorRelay<Int?>(value: nil)
     }
     
     // MARK: - Properites
@@ -43,6 +44,9 @@ final class MainViewModel {
     func transform(input: Input) -> Output {
         let output = Output(ownerType: useCase.fetchOwnerType())
         
+        useCase.firstShowingIndex
+            .bind(to: output.firstShowingIndex)
+            .disposed(by: disposeBag)
         
         input.viewWillAppear
             .subscribe(onNext: { [weak self] _ in

--- a/Dayeng/Dayeng/Util/Enums/OwnerType.swift
+++ b/Dayeng/Dayeng/Util/Enums/OwnerType.swift
@@ -7,7 +7,19 @@
 
 import Foundation
 
-enum OwnerType {
+enum OwnerType: Equatable {
     case mine
     case friend(user: User)
+    
+    
+    static func == (lhs: OwnerType, rhs: OwnerType) -> Bool {
+        switch (lhs, rhs) {
+        case (.mine, .mine):
+            return true
+        case (.friend, .friend):
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/Dayeng/Dayeng/Util/Enums/OwnerType.swift
+++ b/Dayeng/Dayeng/Util/Enums/OwnerType.swift
@@ -11,7 +11,6 @@ enum OwnerType: Equatable {
     case mine
     case friend(user: User)
     
-    
     static func == (lhs: OwnerType, rhs: OwnerType) -> Bool {
         switch (lhs, rhs) {
         case (.mine, .mine):


### PR DESCRIPTION
### 작업내용
- Calendar 버그 수정
      
    | 기존 (오늘 답변 후) | 수정 후 (오늘 답변 후) |
    |:-----:|:-----:|
    |![칼렌다 수정전](https://user-images.githubusercontent.com/57134892/234579993-37b95c1b-df4e-4503-a4fe-8ae7aa377c20.png)|![칼렌다 수정후](https://user-images.githubusercontent.com/57134892/234580088-1c07528a-6a87-4108-b7a8-2eb1faaf3c38.jpeg)|

- Blur
    - 블러에 미쳐있습니다.

    | 기존 | 셀 별 블러처리 후 |
    |:--:|:--:|
    | <img src="https://user-images.githubusercontent.com/57134892/230057119-67215bcd-d394-495b-ac01-654318164160.jpeg" width="393"/> |<img src="https://user-images.githubusercontent.com/57134892/234599406-449f49b2-5e47-420e-ab93-e7fa860dc36f.gif" width="393"/>|

- 칼렌다 - 메인 연결

    ![RPReplay_Final1682518144](https://user-images.githubusercontent.com/57134892/234602360-26d42aaa-7dec-4e62-93d7-8e8671d7cde8.gif)

- 친구 - 메인 연결
    - 메인에 OwnerType을 추가해서 OO했습니다.

    ![RPReplay_Final1682518377](https://user-images.githubusercontent.com/57134892/234603462-0cd90497-4c92-420d-8c80-44f9f9e41d34.gif)


- OwnerType: Equtable
    - parameter가 있는 enum의 경우 비교가 안 되죠?
    - equtable 추가해서, ownerType != .mine 등이 가능합니다.

    ```swift
    enum OwnerType: Equatable {
        case mine
        case friend(user: User)
        
        static func == (lhs: OwnerType, rhs: OwnerType) -> Bool {
            switch (lhs, rhs) {
            case (.mine, .mine):
                return true
            case (.friend, .friend):
                return true
            default:
                return false
            }
        }
    }
    ```
    
### 양심
- [ ] 양심있음
