### PR TITLE
[Setting] 메일 에러 문구 수정

### DIFF
--- a/Dayeng/Dayeng/Presentation/Setting/ViewController/SettingViewController.swift
+++ b/Dayeng/Dayeng/Presentation/Setting/ViewController/SettingViewController.swift
@@ -142,7 +142,7 @@ final class SettingViewController: UIViewController {
             .drive(onNext: { [weak self] type in
                 guard let self else { return }
                 if !MFMailComposeViewController.canSendMail() {
-                    self.showAlert(title: "에러가 발생했어요.", message: "다시 전송해주세요!", type: .oneButton)
+                    self.showAlert(title: "에러가 발생했어요.", message: "메일이 연동되어있는지 확인해주세요.", type: .oneButton)
                     return
                 }
                 


### PR DESCRIPTION
### 작업내용

- 메일 에러가 나는 경우가 iOS 디바이스 내부에서 메일 을 연동하지 않았기때문이기에 인지할 수 있도록 문구 수정